### PR TITLE
fix : mixed content blocked

### DIFF
--- a/user/public/index.html
+++ b/user/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="https://www.onlinemanipal.com/wp-content/uploads/2021/05/fav-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">


### PR DESCRIPTION
Older Version had an error as follows:
Error : mixed content: the page at was loaded over https, but requested an insecure xmlhttprequest endpoint. this request has been blocked; the content must be served over https.

Fix:
<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">